### PR TITLE
Update condition for decimal character to prevent forceclose.

### DIFF
--- a/Calculator/Controller/ViewController.swift
+++ b/Calculator/Controller/ViewController.swift
@@ -58,9 +58,8 @@ class ViewController: UIViewController {
                 
                 if numValue == "." {
                     
-                    let isInt = floor(displayValue) == displayValue
-                    
-                    if !isInt {
+                    let hasDecimalPointCurrently = displayLabel.text!.contains(where: {$0 == "." })
+                    if hasDecimalPointCurrently {
                         return
                     }
                 }


### PR DESCRIPTION
Previous logic occurred force close with this input: "1.00."

floor("1.00.") == "1.00."

instead, check whether the "." character is existed or not.